### PR TITLE
Add more test conditions for StickyEvent

### DIFF
--- a/crates/fluvio-types/src/event.rs
+++ b/crates/fluvio-types/src/event.rs
@@ -249,19 +249,17 @@ mod test {
         let stream2 = stream::repeat(9);
         let _until2 = stream2.take_until(end.listen_pinned());
 
-        // In our real use-case, we need our stream to be `impl Stream + Send + Sync + 'static`
-        fn assert_stream<S: Stream + Send + Sync + 'static>(stream: S) -> S {
-            stream
-        }
-        // The stream needs to be able to be moved, as it will be stored in a struct
-        fn move_it<S>(it: S) -> S {
-            it
-        }
         let stream3 = stream::repeat(9);
         let until3 = stream3.take_until(end.listen_pinned());
-        let until3 = assert_stream(until3);
-        let pinned: Option<Pin<Box<dyn Stream<Item = i32> + Send + Sync>>> = Some(Box::pin(until3));
-        let moved = move_it(pinned);
+        let pinned = Box::pin(until3);
+
+        struct DispatcherStateOrSomething {
+            _stream: Option<Pin<Box<dyn Stream<Item = i32>>>>,
+        }
+
+        let _stored = DispatcherStateOrSomething {
+            _stream: Some(pinned),
+        };
     }
 
     #[fluvio_future::test]


### PR DESCRIPTION
I was able to reproduce the conditions that cause the error that https://github.com/infinyon/fluvio/pull/1652 is supposed to fix. The root problem is that we want to compose our stream in a local scope, but move it (like into a struct) to be used later.

The test now causes this error, the same one I was trying to solve with PR https://github.com/infinyon/fluvio/pull/1652

```
error[E0597]: `end` does not live long enough
   --> crates/fluvio-types/src/event.rs:261:41
    |
261 |         let until3 = stream3.take_until(end.listen_pinned());
    |                                         ^^^----------------
    |                                         |
    |                                         borrowed value does not live long enough
    |                                         argument requires that `end` is borrowed for `'static`
...
265 |     }
    |     - `end` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
error: could not compile `fluvio-types` due to previous error
```